### PR TITLE
also report selected_requests in json

### DIFF
--- a/app/models/obs_factory/staging_project.rb
+++ b/app/models/obs_factory/staging_project.rb
@@ -200,7 +200,7 @@ module ObsFactory
 
     def self.attributes
       %w(name description obsolete_requests openqa_jobs building_repositories
-        broken_packages subprojects untracked_requests missing_reviews)
+        broken_packages subprojects untracked_requests missing_reviews selected_requests )
     end
 
     # Required by ActiveModel::Serializers


### PR DESCRIPTION
this allows the command line client to ignore empty prjs
