### PR TITLE
Adapt routes to be mounted on /

### DIFF
--- a/app/controllers/obs_factory/distributions_controller.rb
+++ b/app/controllers/obs_factory/distributions_controller.rb
@@ -3,7 +3,7 @@ module ObsFactory
     respond_to :html
 
     def show
-      @distribution = Distribution.find(params[:id])
+      @distribution = Distribution.find(params[:project])
       @staging_projects = StagingProjectPresenter.sort(@distribution.staging_projects)
       @versions = { source: @distribution.source_version,
                     totest: @distribution.totest_version,
@@ -15,6 +15,8 @@ module ObsFactory
       @images = ObsProjectPresenter.new(@distribution.images_project)
       @openqa_jobs = @distribution.openqa_jobs_for(:totest)
       calculate_reviews
+      # For the breadcrumbs
+      @project = @distribution.project
     end
 
     protected

--- a/app/controllers/obs_factory/staging_projects_controller.rb
+++ b/app/controllers/obs_factory/staging_projects_controller.rb
@@ -3,22 +3,28 @@ module ObsFactory
     respond_to :json, :html
 
     def index
-      @distribution = Distribution.find(params[:distribution_id])
+      @distribution = Distribution.find(params[:project])
       respond_to do |format|
         format.html do
           @staging_projects = StagingProjectPresenter.sort(@distribution.staging_projects)
           @backlog_requests = Request.with_open_reviews_for(by_group: 'factory-staging')
           @backlog_requests.sort! { |x,y| x.package <=> y.package }
+          # For the breadcrumbs
+          @project = @distribution.project
         end
         format.json { render json: @distribution.staging_projects }
       end
     end
 
     def show
-      @distribution = Distribution.find(params[:distribution_id])
+      @distribution = Distribution.find(params[:project])
       staging_project = @distribution.staging_project(params[:id].upcase)
       respond_to do |format|
-        format.html { @staging_project = StagingProjectPresenter.new(staging_project) }
+        format.html do
+          @staging_project = StagingProjectPresenter.new(staging_project)
+          # For the breadcrumbs
+          @project = @distribution.project
+        end
         format.json { render json: staging_project }
       end
     end

--- a/app/views/obs_factory/distributions/show.html.haml
+++ b/app/views/obs_factory/distributions/show.html.haml
@@ -1,8 +1,11 @@
+-# Depends on https://github.com/openSUSE/open-build-service/pull/762
+-# project_bread_crumb 'Dashboard'
+
 %div{class: "grid_16 alpha"}
   %div{class: "box box-shadow"}
     %h2
       %i{class: "fa fa-2 fa-tasks"}
-      = link_to "Staging Projects", distribution_staging_projects_path(@distribution.id)
+      = link_to "Staging Projects", staging_projects_path(project: @distribution.name)
     %ul{id: 'main-dashboard'}
       - @staging_projects.each do |project|
         - next if project.overall_state == :empty
@@ -13,7 +16,7 @@
 
     %h2
       %i{class: "fa fa-2 fa-circle-o"}
-      = link_to "Ring Projects", main_app.project_subprojects_path(project: 'openSUSE:Factory:Rings')
+      = link_to "Ring Projects", main_app.project_subprojects_path(project: "#{@distribution.name}:Rings")
 
     %ul{id: 'ring-projects', class: 'project-results'}
       - @ring_prjs.each do |rp|

--- a/app/views/obs_factory/staging_projects/_overall_state.html.haml
+++ b/app/views/obs_factory/staging_projects/_overall_state.html.haml
@@ -1,6 +1,6 @@
 %div{class: "overall-state staging-project state-#{project.overall_state}"}
   %div{class: 'letter'}
-    = link_to project.letter, distribution_staging_project_path(@distribution.id, project.id)
+    = link_to project.letter, staging_project_path(project: @distribution.name, id: project.id)
   %div{class: 'state'} 
     = link_to project.overall_state, main_app.project_show_path(project.name)
   %div{class: 'progress'}

--- a/app/views/obs_factory/staging_projects/index.html.haml
+++ b/app/views/obs_factory/staging_projects/index.html.haml
@@ -1,3 +1,6 @@
+-# Depends on https://github.com/openSUSE/open-build-service/pull/762
+-# project_bread_crumb 'Staging projects'
+
 %div{class: "grid_13 alpha"}
   %div{class: "box box-shadow"}
 

--- a/app/views/obs_factory/staging_projects/show.html.erb
+++ b/app/views/obs_factory/staging_projects/show.html.erb
@@ -1,3 +1,6 @@
+<%# Depends on https://github.com/openSUSE/open-build-service/pull/762 %>
+<%# project_bread_crumb link_to('Staging projects', staging_projects_path(project: @distribution.name)), @staging_project.id %>
+
 <h1><%= @staging_project.name %></h1>
 
 <h2>Packages</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,16 @@
 ObsFactory::Engine.routes.draw do
-  resources :distributions, only: [:show], constraints: {id: %r{[^\/]*}} do
-    # Status of staging projects (as status pages or as JSON structures)
-    resources :staging_projects, only: [:index, :show], controller: :staging_projects
-  end
+  cons = { project: %r{[^\/]*} }
+  get 'project/dashboard/:project' => "distributions#show", as: 'dashboard', constraints: cons
+  get 'project/staging_projects/:project' => "staging_projects#index", as: 'staging_projects', contraints: cons
+  get 'project/staging_projects/:project/:id' => "staging_projects#show", as: 'staging_project', contraints: cons
+
   # Used to enforce the refresh of the cache of jobs (using cache=refresh)
-  get '/openqa_jobs' => 'openqa_jobs#index'
+  get 'openqa_jobs' => 'openqa_jobs#index'
+
+  # Compatibility with old build.opensuse.org routes
+  old_mount_point = 'factory'
+  get "#{old_mount_point}/dashboard", to: redirect('project/dashboard/openSUSE:Factory')
+  get "#{old_mount_point}/staging_projects", to: redirect('project/staging_projects/openSUSE:Factory')
+  get "#{old_mount_point}/staging_projects/:id", to: redirect('project/staging_projects/openSUSE:Factory/%{id}')
+  get "#{old_mount_point}/openqa_jobs", to: redirect('openqa_jobs')
 end


### PR DESCRIPTION
- New routes follow the OBS convention /project/:action/:project_name
- Redirects for the old /factory routes
- Everything in place to draw the expected breadcrumbs
- A minor fix in the dashboard view
