### PR TITLE
Fixed a typo in routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 ObsFactory::Engine.routes.draw do
   cons = { project: %r{[^\/]*} }
   get 'project/dashboard/:project' => "distributions#show", as: 'dashboard', constraints: cons
-  get 'project/staging_projects/:project' => "staging_projects#index", as: 'staging_projects', contraints: cons
+  get 'project/staging_projects/:project' => "staging_projects#index", as: 'staging_projects', constraints: cons
   get 'project/staging_projects/:project/:id' => "staging_projects#show", as: 'staging_project', contraints: cons
 
   # Used to enforce the refresh of the cache of jobs (using cache=refresh)


### PR DESCRIPTION
Beware: as a consequence, the old routes /project/staging_projects/XX.json
don't work any longer. Use /project/staging_projects/XX?format=json
