### PR TITLE
Provide access to all stagings in aggregate json output.

### DIFF
--- a/app/controllers/obs_factory/staging_projects_controller.rb
+++ b/app/controllers/obs_factory/staging_projects_controller.rb
@@ -20,7 +20,7 @@ module ObsFactory
           # For the breadcrumbs
           @project = @distribution.project
         end
-        format.json { render json: @distribution.staging_projects }
+        format.json { render json: @distribution.staging_projects_all }
       end
     end
 

--- a/app/models/obs_factory/distribution.rb
+++ b/app/models/obs_factory/distribution.rb
@@ -108,6 +108,13 @@ module ObsFactory
       @staging_projects ||= StagingProject.for(self)
     end
 
+    # Staging projects associated to the distribution, including non-letter
+    #
+    # @return [Array] array of StagingProject objects
+    def staging_projects_all
+      @staging_projects ||= StagingProject.for(self, false)
+    end
+
     # Staging project associated to the distribution and with the given id
     #
     # @param [String] id of the staging project

--- a/app/models/obs_factory/staging_project.rb
+++ b/app/models/obs_factory/staging_project.rb
@@ -20,9 +20,11 @@ module ObsFactory
 
     # Find all staging projects for a given distribution
     #
+    # @param [Boolean] only_letter  only letter stagings, otherwise all stagings
     # @return [Array] array of StagingProject objects
-    def self.for(distribution)
-      ::Project.where(["name like ?", "#{distribution.root_project_name}#{NAME_PREFIX}_"]).map { |p| StagingProject.new(p, distribution) }
+    def self.for(distribution, only_letter=true)
+      wildcard = only_letter ? "_" : "%"
+      ::Project.where(["name like ?", "#{distribution.root_project_name}#{NAME_PREFIX}#{wildcard}"]).map { |p| StagingProject.new(p, distribution) }
     end
 
     # Find a staging project by distribution and id


### PR DESCRIPTION
I imagine this could be done in a variety of ways, one including an additional parameter, but given the hackweek project to display adi stagings on aggregate dashboard this simpler style seems to fit nicely since both will display all stagings (one being tabbed). The idea here is to cut the number of queries the `osc staging` tools have to run when querying the status of stagings. In Factory (and Leap 42.3 currently) there are dozens if not hundreds of adi stagings that are requested individually. This changes the aggregate JSON output to include non-letter stagings so that the tools can then be altered to utilize it.

Cuts number of queries from a couple hundred to one.