### PR TITLE
Display project splitter_info, if available, on summary dashboard.

### DIFF
--- a/app/assets/stylesheets/obs_factory/application.css
+++ b/app/assets/stylesheets/obs_factory/application.css
@@ -212,6 +212,25 @@ a.openqa-incomplete {
     color: white;
 }
 
+.staging-project .splitter-info {
+    margin-top: 5px;
+    background-color: white;
+    border-radius: 5px;
+    box-shadow: 0px -2px 2px #999;
+    cursor: default;
+}
+
+.staging-project .splitter-info div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 7em;
+}
+
+.staging-project .splitter-info div:hover {
+    overflow: visible;
+    max-width: none;
+}
+
 ul.color-legend {
     list-style-type: none;
     margin-left: 4px;

--- a/app/views/obs_factory/staging_projects/_overall_state.html.haml
+++ b/app/views/obs_factory/staging_projects/_overall_state.html.haml
@@ -13,3 +13,10 @@
     - elsif project.overall_state == :testing
       = link_to "https://openqa.opensuse.org/tests?hoursfresh=24&#{@distribution.openqa_filter(project)}" do
         = "#{project.testing_percentage}%"
+  - if project.meta['splitter_info']
+    %div{class: 'splitter-info', title: 'strategy information (name, group)'}
+      - splitter_info = project.meta['splitter_info']
+      %div{class: 'splitter-info-strategy'}
+        = "#{splitter_info['strategy']['name']}"
+      %div{class: 'splitter-info-group'}
+        = "#{splitter_info['group']}"


### PR DESCRIPTION
The `splitter_info` is written by the select proposal tool and is helpful for understanding the reason behind the contents of a staging.