### PR TITLE
Separate ignored backlog requests into separate list.

### DIFF
--- a/app/assets/stylesheets/obs_factory/application.css
+++ b/app/assets/stylesheets/obs_factory/application.css
@@ -245,7 +245,8 @@ ul.color-legend li {
     margin-right: 8px;
 }
 
-.staging_backlog li {
+.staging_backlog li,
+.staging_backlog_ignored li {
     margin-left: 8px;
 }
 

--- a/app/controllers/obs_factory/staging_projects_controller.rb
+++ b/app/controllers/obs_factory/staging_projects_controller.rb
@@ -16,6 +16,20 @@ module ObsFactory
         format.html do
           @staging_projects = StagingProjectPresenter.sort(@distribution.staging_projects)
           @backlog_requests = Request.with_open_reviews_for(by_group: 'factory-staging', target_project: @distribution.name)
+          file = PackageFile.new(
+            project_name: "#{params[:project]}:Staging",
+            package_name: "dashboard",
+            name: "ignored_requests")
+          unless file.to_s.nil?
+            @ignored_requests = YAML.load(file.to_s)
+          end
+          if !@ignored_requests.nil? and @ignored_requests
+            @backlog_requests_ignored = @backlog_requests.select { |req| @ignored_requests.key?(req.number) }
+            @backlog_requests = @backlog_requests.select { |req| !@ignored_requests.key?(req.number) }
+            @backlog_requests_ignored.sort! { |x,y| x.package <=> y.package }
+          else
+            @backlog_requests_ignored = []
+          end
           @backlog_requests.sort! { |x,y| x.package <=> y.package }
           # For the breadcrumbs
           @project = @distribution.project

--- a/app/views/obs_factory/staging_projects/_infos.html.haml
+++ b/app/views/obs_factory/staging_projects/_infos.html.haml
@@ -26,3 +26,13 @@
         - if counter > 5 && @backlog_requests.size > counter + 1
           %li ... #{@backlog_requests.size - counter} more
           - break
+
+  - if @backlog_requests_ignored.present?
+    %p Ignored:
+    %ul{class: "staging_backlog_ignored"}
+      - @backlog_requests_ignored.each_with_index do |req,counter|
+        %li
+          = link_to elide(req.package, length = 19), main_app.request_show_path(req.number), title: @ignored_requests[req.number]
+        - if counter > 5 && @backlog_requests_ignored.size > counter + 1
+          %li ... #{@backlog_requests_ignored.size - counter} more
+          - break

--- a/app/views/obs_factory/staging_projects/_infos.html.haml
+++ b/app/views/obs_factory/staging_projects/_infos.html.haml
@@ -18,11 +18,9 @@
       %i Empty
   - else
     %ul{class: "staging_backlog"}
-      - counter = 0
-      - @backlog_requests.each do |req|
+      - @backlog_requests.each_with_index do |req,counter|
         %li
           = link_to elide(req.package, length = 19), main_app.request_show_path(req.number)
-        - counter += 1
         - if counter > 5 && @backlog_requests.size > counter + 1
           %li ... #{@backlog_requests.size - counter} more
           - break


### PR DESCRIPTION
A useful distinction to make. Reason is displayed on hover.

Confirmed this works if:
- `dashboard` package does not exists
- `ignored_requests` file does not exits
- `ignored_requests` is empty
- `ignored_requests` is not empty