### PR TITLE
Fix published_version return nil for Leap

### DIFF
--- a/app/models/obs_factory/distribution_strategy_opensuse.rb
+++ b/app/models/obs_factory/distribution_strategy_opensuse.rb
@@ -32,6 +32,23 @@ module ObsFactory
       "openSUSE-#{opensuse_version}-Staging"
     end
 
+    def published_arch
+        'x86_64'
+    end
+
+    # Version of the published distribution
+    #
+    # @return [String] version string
+    def published_version
+      begin
+        f = open(repo_url)
+      rescue OpenURI::HTTPError => e
+        return 'unknown'
+      end
+      matchdata = %r{openSUSE-#{opensuse_leap_version}-#{published_arch}-Build(.*)}.match(f.read)
+      matchdata[1]
+    end
+
     # URL parameter for 42
     def openqa_filter(project)
       return "match=42:S:#{project.letter}"


### PR DESCRIPTION
Build name in 42.3 is openSUSE-42.3-x86_64-Build0144 what matchdata regex will return nil for matchdata[1]. Update regex for Leap.