### PR TITLE
Fix testing broken

### DIFF
--- a/app/models/obs_factory/staging_project.rb
+++ b/app/models/obs_factory/staging_project.rb
@@ -54,12 +54,22 @@ module ObsFactory
       project.description
     end
 
+    # Checks if the project is adi staging project
+    #
+    # @return [Boolean] true if the project is adi staging project
+    def adi_staging?
+      if name =~ /#{ADI_NAME_PREFIX}/
+        return true
+      end
+      false
+    end
+
     # Part of the name shared by all the staging projects belonging to the same
     # distribution
     #
     # @return [String] the name excluding the id
     def prefix
-      if name =~ /#{ADI_NAME_PREFIX}/
+      if adi_staging?
         "#{distribution.root_project_name}#{ADI_NAME_PREFIX}"
       else
         "#{distribution.root_project_name}#{NAME_PREFIX}"
@@ -70,14 +80,14 @@ module ObsFactory
     #
     # @return [String] just the letter
     def letter
-      name =~ /#{ADI_NAME_PREFIX}/ ? name[prefix.size..-1] : name[prefix.size, 1]
+      adi_staging? ? name[prefix.size..-1] : name[prefix.size, 1]
     end
 
     # Id of the staging project, extracted from its name
     #
     # @return [String] the name excluding the common prefix
     def id
-      if name =~ /#{ADI_NAME_PREFIX}/
+      if adi_staging?
         'adi:' + name[prefix.size..-1]
       else
         name[prefix.size..-1]
@@ -254,7 +264,7 @@ module ObsFactory
     # check openQA jobs for all projects not building right now - or that are known to be broken
     def openqa_state
       # no openqa result for adi staging project
-      return :acceptable if name =~ /#{ADI_NAME_PREFIX}/
+      return :acceptable if adi_staging?
       # the ISOs may still be syncing
       return :testing if openqa_jobs.empty?
 

--- a/app/models/obs_factory/staging_project.rb
+++ b/app/models/obs_factory/staging_project.rb
@@ -253,6 +253,8 @@ module ObsFactory
 
     # check openQA jobs for all projects not building right now - or that are known to be broken
     def openqa_state
+      # no openqa result for adi staging project
+      return :acceptable if name =~ /#{ADI_NAME_PREFIX}/
       # the ISOs may still be syncing
       return :testing if openqa_jobs.empty?
 

--- a/app/models/obs_factory/staging_project.rb
+++ b/app/models/obs_factory/staging_project.rb
@@ -70,7 +70,7 @@ module ObsFactory
     #
     # @return [String] just the letter
     def letter
-      name[prefix.size..-1]
+      name =~ /#{ADI_NAME_PREFIX}/ ? name[prefix.size..-1] : name[prefix.size, 1]
     end
 
     # Id of the staging project, extracted from its name

--- a/app/views/obs_factory/staging_projects/_infos.html.haml
+++ b/app/views/obs_factory/staging_projects/_infos.html.haml
@@ -2,7 +2,7 @@
   %h2{class: "box-header"} Infos
 
   %p Empty Projects:
-  - empties = @staging_projects.select { |p| p.overall_state == :empty }
+  - empties = @staging_projects.select { |p| p.overall_state == :empty && p.name =~ /Staging:[A-Z]?$/ }
   - empties = empties.map { |p| link_to(p.letter, main_app.project_show_path(p.name)) }
 
   %p


### PR DESCRIPTION
Query X:DVD as letter won't work on openQA result query, eg. the iso name will not match, change it back to name[prefix.size, 1] for letter staging, also use name[prefix.size..-1] in case it's adi then will not break adi project name in the overall.