### PR TITLE
adapt hard coded package name from _product to 000product

### DIFF
--- a/app/models/obs_factory/distribution.rb
+++ b/app/models/obs_factory/distribution.rb
@@ -11,7 +11,7 @@ module ObsFactory
     extend ActiveModel::Naming
     extend Forwardable
     
-    SOURCE_VERSION_FILE = "_product/openSUSE.product"
+    SOURCE_VERSION_FILE = "000product/openSUSE.product"
     RINGS_PREFIX = ":Rings"
 
     attr_accessor :project, :strategy

--- a/app/models/obs_factory/distribution_strategy_factory.rb
+++ b/app/models/obs_factory/distribution_strategy_factory.rb
@@ -25,7 +25,7 @@ module ObsFactory
     end
 
     def totest_version_file
-      'images/local/_product:openSUSE-cd-mini-x86_64'
+      'images/local/000product:openSUSE-cd-mini-x86_64'
     end
 
     def arch

--- a/app/models/obs_factory/distribution_strategy_factory_ppc.rb
+++ b/app/models/obs_factory/distribution_strategy_factory_ppc.rb
@@ -8,7 +8,7 @@ module ObsFactory
     end
 
     def totest_version_file
-      'images/local/_product:openSUSE-cd-mini-ppc64le'
+      'images/local/000product:openSUSE-cd-mini-ppc64le'
     end
 
     def arch

--- a/app/views/obs_factory/distributions/show.html.haml
+++ b/app/views/obs_factory/distributions/show.html.haml
@@ -73,7 +73,7 @@
       - if @versions[:source]
         %li
           Source:
-          = link_to @versions[:source], main_app.package_show_path(project: "#{@distribution.name}", package: '_product')
+          = link_to @versions[:source], main_app.package_show_path(project: "#{@distribution.name}", package: '000product')
 
       - if @versions[:totest]
         %li


### PR DESCRIPTION
The better fix would be to use product interface to search for right
container. But there are plenty of other project names hardcoded as well atm