### PR TITLE
Dashboard updates

### DIFF
--- a/app/controllers/obs_factory/distributions_controller.rb
+++ b/app/controllers/obs_factory/distributions_controller.rb
@@ -34,7 +34,6 @@ module ObsFactory
       @reviews[:review_team]  = @distribution.requests_with_reviews_for_group('opensuse-review-team').size
       @reviews[:factory_auto] = @distribution.requests_with_reviews_for_group('factory-auto').size
       @reviews[:legal_auto]   = @distribution.requests_with_reviews_for_group('legal-auto').size
-      @reviews[:legal_team]   = @distribution.requests_with_reviews_for_group('legal-team').size
       @reviews[:repo_checker] = @distribution.requests_with_reviews_for_user('repo-checker').size
     end
   end

--- a/app/controllers/obs_factory/distributions_controller.rb
+++ b/app/controllers/obs_factory/distributions_controller.rb
@@ -35,7 +35,7 @@ module ObsFactory
       @reviews[:factory_auto] = @distribution.requests_with_reviews_for_group('factory-auto').size
       @reviews[:legal_auto]   = @distribution.requests_with_reviews_for_group('legal-auto').size
       @reviews[:legal_team]   = @distribution.requests_with_reviews_for_group('legal-team').size
-      @reviews[:repo_checker] = @distribution.requests_with_reviews_for_user('factory-repo-checker').size
+      @reviews[:repo_checker] = @distribution.requests_with_reviews_for_user('repo-checker').size
     end
   end
 end

--- a/app/presenters/obs_factory/staging_project_presenter.rb
+++ b/app/presenters/obs_factory/staging_project_presenter.rb
@@ -35,7 +35,7 @@ module ObsFactory
       case reviewer
       when 'opensuse-review-team' then
         'search'
-      when 'factory-repo-checker' then
+      when 'repo-checker' then
         'cog'
       when 'sle-release-managers', 'leap-reviewers', 'caasp-release-managers' then
         'users'

--- a/app/views/obs_factory/distributions/show.html.haml
+++ b/app/views/obs_factory/distributions/show.html.haml
@@ -61,10 +61,6 @@
       %li
         Factory Repo Checker:
         = @reviews[:repo_checker]
-
-      %li
-        Legal Team:
-        = @reviews[:legal_team]
     %h2
       %i{class: "fa fa-2 fa-tag"}
       = link_to "Versions", "http://download.opensuse.org/#{@distribution.url_suffix}"


### PR DESCRIPTION
* factory-repo-checker group is renamed to repo-checker: show the new values on the dashboard
* legal-team has no relevance to the Factory process anymore (legal-auto is the only reviewer used in the process)