### PR TITLE
Live images are now built in /images (no more /standard)

### DIFF
--- a/app/models/obs_factory/distribution.rb
+++ b/app/models/obs_factory/distribution.rb
@@ -190,7 +190,7 @@ module ObsFactory
         if @live_project.project.nil?
           @live_project = nil
         else
-          @live_project.exclusive_repository = 'standard'
+          @live_project.exclusive_repository = 'images'
         end
       end
       @live_project


### PR DESCRIPTION
Since the live images are now built as 'real' kiwi builds (instead of
kiwi builds wrapped inside .spec files), we now need to monitor the
/images repository.