### PR TITLE
Stop raising excpetions for normalities, log instead

### DIFF
--- a/app/models/obs_factory/openqa_api.rb
+++ b/app/models/obs_factory/openqa_api.rb
@@ -41,7 +41,10 @@ module ObsFactory
       uri.query = params.to_query
      
       resp = _get(uri)
-      raise OpenqaFailure, "OpenQA API GET failure: \"#{url}\" with \"#{params.to_query}\"" unless resp.code.to_i == 200
+      unless resp.code.to_i == 200
+        Rails.logger.error "OpenQA API GET failure: \"#{url}\" with \"#{params.to_query}\""
+        return Hash.new
+      end
       ActiveSupport::JSON.decode(resp.body)
     end
   end

--- a/app/models/obs_factory/staging_project.rb
+++ b/app/models/obs_factory/staging_project.rb
@@ -113,7 +113,11 @@ module ObsFactory
         p.parent = self
         @subprojects << p
       end
-      raise 'now we have a problem' if @subprojects.length > 1
+      if @subprojects.length > 1
+        Rails.logger.error 'There too many subprojects, we can not handle this'
+        @subprojects[0] = nil
+        return
+      end
       @subprojects[0] ||= nil
     end
 

--- a/app/presenters/obs_factory/staging_project_presenter.rb
+++ b/app/presenters/obs_factory/staging_project_presenter.rb
@@ -182,7 +182,8 @@ module ObsFactory
       when :empty
         60000
       else
-        raise "untracked #{overall_state}"
+        Rails.logger.error "untracked #{overall_state}"
+        return
       end
       main + letter.ord()
     end


### PR DESCRIPTION
Everytime openQA is down the OBS exception tracker feels like Huston after Harvey...