### PR TITLE
Fix broken openQA links at staging projects page

### DIFF
--- a/app/models/obs_factory/openqa_job.rb
+++ b/app/models/obs_factory/openqa_job.rb
@@ -14,6 +14,10 @@ module ObsFactory
       CONFIG['openqa_base_url'] || "http://openqa.opensuse.org"
     end
 
+    def self.openqa_links_url
+      CONFIG['openqa_links_url'] || "http://openqa.opensuse.org"
+    end
+
     @@api = ObsFactory::OpenqaApi.new(openqa_base_url)
 
     # Reads jobs from the openQA instance or the cache with an interface similar

--- a/app/presenters/obs_factory/openqa_job_presenter.rb
+++ b/app/presenters/obs_factory/openqa_job_presenter.rb
@@ -5,7 +5,7 @@ module ObsFactory
     #
     # @return [String] the full URL
     def url
-      OpenqaJob.openqa_base_url.chomp('/') + "/tests/#{id}"
+      OpenqaJob.openqa_links_url.chomp('/') + "/tests/#{id}"
     end
 
     # The part of the name that refers to the testsuite


### PR DESCRIPTION
Related to https://github.com/openSUSE/obs_factory/issues/86