### PR TITLE
openqa_iso: update the logic to get the proper iso matches for Leap 15.0

### DIFF
--- a/app/models/obs_factory/distribution_strategy_factory.rb
+++ b/app/models/obs_factory/distribution_strategy_factory.rb
@@ -64,9 +64,9 @@ module ObsFactory
     def openqa_iso(project)
       iso = project_iso(project)
       return nil if iso.nil?
-      ending = iso[5..-1] # Everything but the initial 'Test-'
+      ending = iso.gsub!(/.*-Build/, '')
       suffix = /DVD$/ =~ project.name ? 'Staging2' : 'Staging'
-      openqa_iso_prefix + ":#{project.letter}-#{suffix}-DVD-#{arch}-#{ending}"
+      openqa_iso_prefix + ":#{project.letter}-#{suffix}-DVD-#{arch}-Build#{ending}"
     end
 
     # Name of the ISO file produced by the given staging project's Test-DVD


### PR DESCRIPTION
TW: Test-Build741.3-Media.iso
Leap 15.0: openSUSE-Leap-15.0-DVD-x86_64-Build13.2-Media.iso