### PR TITLE
Wrap long text elements in problems table cell

### DIFF
--- a/app/assets/stylesheets/obs_factory/application.css
+++ b/app/assets/stylesheets/obs_factory/application.css
@@ -160,11 +160,13 @@ a.openqa-incomplete {
     text-align: left;
     margin-top: 0px;
     list-style-type: none;
+    word-break: break-all;
 }
 
 #staging-dashboard ul.problem_list li {
     margin-left: 8px;
     line-height: 170%;
+    white-space: normal
 }
 
 #staging-dashboard .delete a {


### PR DESCRIPTION
Since i saw this issue again today, i applied some css to wrap the text in case it gets to long. There is no logic behind, so it will just wrap the text somewhere.  
![screenshot from 2017-11-27 14 31 51](https://user-images.githubusercontent.com/22001671/33269243-471743a8-d380-11e7-9dc7-376d732aec61.png)
