### PR TITLE
Trivial: use tumbleweed/iso; factory/iso is the legacy name

### DIFF
--- a/app/models/obs_factory/distribution_strategy_factory.rb
+++ b/app/models/obs_factory/distribution_strategy_factory.rb
@@ -36,7 +36,7 @@ module ObsFactory
     end
 
     def url_suffix
-      'factory/iso'
+      'tumbleweed/iso'
     end
 
     def rings


### PR DESCRIPTION
of course, factory/iso still works too - but no reason to not change it