### PR TITLE
Add fallback for failing openqa get request and missing parameters in query

### DIFF
--- a/app/models/obs_factory/openqa_job.rb
+++ b/app/models/obs_factory/openqa_job.rb
@@ -85,8 +85,11 @@ module ObsFactory
         get_params.merge!(filter)
         jobs = @@api.get('jobs', get_params)['jobs']
       end
-
-      jobs.map { |j| OpenqaJob.new(j.slice(*attributes)) }
+      unless jobs.nil?
+        jobs.map { |j| OpenqaJob.new(j.slice(*attributes)) }
+      else
+        return Hash.new
+      end
     end
 
     # Name of the modules which failed during openQA execution

--- a/app/views/obs_factory/distributions/show.html.haml
+++ b/app/views/obs_factory/distributions/show.html.haml
@@ -90,6 +90,9 @@
       = link_to "openQA results for #{@versions[:totest]}", "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&build=#{@versions[:totest]}&group=#{@distribution.openqa_group}"
 
     %p
-      - @openqa_jobs.group_by(&:result_or_state).each do |label, jobs|
-        %b= "#{label}:"
-        = jobs.size
+      - unless @openqa_jobs.empty?
+        - @openqa_jobs.group_by(&:result_or_state).each do |label, jobs|
+          %b= "#{label}:"
+          = jobs.size
+      - else
+        OpenQA currently not reachable or failure in GET request


### PR DESCRIPTION
Still have to make the error handling/messages more specific and to move some logic from the view but this already prevents some trouble if something goes wrong with the openQA communication.