### PR TITLE
Published version: adjusts repo_url for product builder

### DIFF
--- a/app/models/obs_factory/distribution_strategy_factory.rb
+++ b/app/models/obs_factory/distribution_strategy_factory.rb
@@ -44,7 +44,7 @@ module ObsFactory
     end
 
     def repo_url
-      'http://download.opensuse.org/factory/repo/oss/media.1/build'
+      'http://download.opensuse.org/tumbleweed/repo/oss/media.1/media'
     end
 
     def published_arch


### PR DESCRIPTION
there is no longer have `build` file under `media.1`